### PR TITLE
Add drag stop binding

### DIFF
--- a/ss_window.py
+++ b/ss_window.py
@@ -22,6 +22,7 @@ class Overlay(tk.Toplevel):
         self.drag_handle.place(relx=0.5, rely=0, anchor='n')
         self.drag_handle.bind("<ButtonPress-1>", self.start_drag)
         self.drag_handle.bind("<B1-Motion>", self.do_drag)
+        self.drag_handle.bind("<ButtonRelease-1>", self.stop_drag)
         
         self.resizing = False
         self.start_x = None

--- a/ss_window.pyw
+++ b/ss_window.pyw
@@ -24,6 +24,7 @@ class Overlay(tk.Toplevel):
         self.drag_handle.place(relx=0.5, rely=0, anchor='n')
         self.drag_handle.bind("<ButtonPress-1>", self.start_drag)
         self.drag_handle.bind("<B1-Motion>", self.do_drag)
+        self.drag_handle.bind("<ButtonRelease-1>", self.stop_drag)
 
         # Add text to the drag handle
         self.drag_text = tk.Label(self.drag_handle, text="Overlay", bg='grey', fg='white')


### PR DESCRIPTION
## Summary
- bind `<ButtonRelease-1>` to `stop_drag` so dragging ends when the mouse button is released

## Testing
- `python -m py_compile ss_window.py ss_window.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68470145ddd08326b08f35f234303552