### PR TITLE
Add requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ A small collection of desktop tools to work around silly corporate environment r
 - [ss_window.py](./docs/ss-window.md)
 - [mouse_jiggle.py](./docs/mouse.md)
 
+## Installation
+
+Clone the repository and install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+
 ## Version History
 
 | Version | Description |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyautogui
+keyboard
+pywin32


### PR DESCRIPTION
## Summary
- provide a Python `requirements.txt`
- add a simple installation section using that file

## Testing
- `pip install -r requirements.txt` *(fails: `pywin32` has no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6847047b756c832699626fcd2a48238b