### PR TITLE
Add CLI options, policy notes, and tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 A small collection of desktop tools to work around silly corporate environment restrictions and improve productivity!
 
+> **Important**
+> These scripts simulate user input to bypass certain restrictions. Always verify that you have permission from your organisation before running them.
+
 ## Tools
 
 - [pasta.py](./docs/pasta.md)
 - [ss_window.py](./docs/ss-window.md)
 - [mouse_jiggle.py](./docs/mouse.md)
+
+Both `pasta.py` and `mouse_jiggle.py` now accept command line arguments. Run each
+script with the `-h` flag to see available options.
 
 ## Installation
 
@@ -15,6 +21,10 @@ Clone the repository and install the required packages:
 ```bash
 pip install -r requirements.txt
 ```
+
+These tools are primarily tested on Windows. `pasta.py` may work on some Linux
+desktops if clipboard and automation permissions are enabled. macOS is not
+supported.
 
 
 ## Version History

--- a/docs/mouse.md
+++ b/docs/mouse.md
@@ -4,6 +4,9 @@
 
 Mouse Jiggle is a simple Python script designed to keep your remote desktop session active by slightly moving the mouse cursor at regular intervals. This prevents the remote desktop from logging out due to inactivity.
 
+> **Warning**
+> Use only where permitted. Simulating activity may violate corporate policies.
+
 ## Author
 
 Wes Moskal-Fitzpatrick
@@ -32,10 +35,11 @@ Wes Moskal-Fitzpatrick
 
 1. Clone this repository or download the script directly.
 
-2. Run the script using Python:
+2. Run the script using Python. You can change the distance moved and pause
+   between movements:
 
    ```bash
-   python mouse_jiggle.py
+   python mouse_jiggle.py --distance 10 --interval 1.0
    ```
 
 ### How It Works

--- a/docs/pasta.md
+++ b/docs/pasta.md
@@ -8,6 +8,9 @@ Pasta uses modules like pyautogui and keyboard to read the text in your clipboar
 
 Because this is not true copy and paste functionality, there may be bugs - particularly on non-QWERTY keyboards. Use at your own discretion.
 
+> **Note**
+> Always ensure you have permission from your employer before using this tool.
+
 ## OS Support
 
 | OS | Support |
@@ -16,19 +19,26 @@ Because this is not true copy and paste functionality, there may be bugs - parti
 | **Linux** | Maybe? |
 | **Mac** | No |
 
+Linux support varies depending on the desktop environment. Clipboard access and
+keyboard automation permissions must be enabled for the script to work properly.
+
 ## How to Use
 
 1. Copy the block of text you need
 
 ![Copy Text](../images/4c91b4ec95d542dab9234bc67db414c7.png?raw=true)
 
-3. Run the executable "pasta.exe"
+3. Run the script and optionally specify a countdown time:
+
+   ```bash
+   python pasta.py --timer 5
+   ```
 4. Have your Notepad/Text app open on the target desktop
 
 ![Ready to Paste](../images/2bf244f3161541a1a0a0949e5f0a0b18.png?raw=true)
 
 5. Click the "Ready" button
-6. During the 3 second countdown, hover over your target window
+6. During the countdown (default is 3 seconds), hover over your target window
 7. Marvel at how quickly you typed that document!
 
 ![Marvel](../images/f1956e3209c5413ba13db32ccc0581f4.png?raw=true)

--- a/docs/ss-window.md
+++ b/docs/ss-window.md
@@ -2,6 +2,9 @@
 
 This project creates a transparent, resizable, and movable overlay window for screen sharing on ultra-wide monitors. It allows you to share a portion of your desktop without having to set a specific application, enabling seamless switching between different applications during screen sharing sessions.
 
+> **Reminder**
+> Ensure screen sharing tools like this comply with your organization's security policies.
+
 ## Features
 
 - **Resizable and movable window:** The window can be resized and moved around the screen.
@@ -42,7 +45,9 @@ Run the `screen_share_window.py` script:
 python screen_share_window.pyw
 ```
 
-Or double-click from Windows Explorer.
+`screen_share_window.pyw` launches the GUI without opening a console window on
+Windows. Use `screen_share_window.py` if you prefer to see console output. You
+can also double-click the `.pyw` file from Explorer.
 
 ## License
 

--- a/mouse_jiggle.py
+++ b/mouse_jiggle.py
@@ -6,13 +6,33 @@
 # Jiggle the mouse a little bit and prevent remote desktop logout.
 #
 
+import argparse
 import pyautogui
 
-while True:
-    pyautogui.moveRel(5,0, duration=0)
-    #pyautogui.moveRel(0,5, duration=0.25)
-    pyautogui.PAUSE = 0.5
-    pyautogui.moveRel(-5,0, duration=0)
-    #pyautogui.moveRel(0,-5, duration=0.25)
-    #pyautogui.click()
-    pyautogui.press('shift')
+
+def main(distance, interval):
+    while True:
+        pyautogui.moveRel(distance, 0, duration=0)
+        pyautogui.PAUSE = interval
+        pyautogui.moveRel(-distance, 0, duration=0)
+        pyautogui.press("shift")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Keep the system active")
+    parser.add_argument(
+        "-d",
+        "--distance",
+        type=int,
+        default=5,
+        help="Distance in pixels to move the mouse",
+    )
+    parser.add_argument(
+        "-i",
+        "--interval",
+        type=float,
+        default=0.5,
+        help="Pause between movements in seconds",
+    )
+    args = parser.parse_args()
+    main(args.distance, args.interval)

--- a/pasta.py
+++ b/pasta.py
@@ -16,46 +16,65 @@
 # 2020-09-24 : 0.2 : WMF : Removed commented out test code.
 #
 
+import argparse
 import tkinter
 import time
 import pyautogui
 import keyboard
 
-def countDown():
-    '''start countdown seconds'''
-    for k in range(3, -1, -1):
-        clock["text"] = k
-        time.sleep(1)
-        root.update() # Tk needs this after sleep()
-    clock["text"] = "Done"
 
-root = tkinter.Tk()
-root.geometry("200x100")
-root.title('Pasta')
-root.attributes("-topmost", True)
+def main(countdown):
+    def countDown():
+        """start countdown seconds"""
+        for k in range(countdown, -1, -1):
+            clock["text"] = k
+            time.sleep(1)
+            root.update()  # Tk needs this after sleep()
+        clock["text"] = "Done"
 
-def submitFunction():
-    global clipboard
-    button.place_forget()
-    countDown()
-    
-    # Click into window
-    x, y = pyautogui.position()
-    pyautogui.click(x, y)
+    root = tkinter.Tk()
+    root.geometry("200x100")
+    root.title('Pasta')
+    root.attributes("-topmost", True)
 
-    # "Paste"
-    keyboard.write(clipboard)
-    ready.set(1)
+    def submitFunction():
+        button.place_forget()
+        countDown()
 
-clipboard = root.clipboard_get()
+        # Click into window
+        x, y = pyautogui.position()
+        pyautogui.click(x, y)
 
-clock = tkinter.Label()
-clock.place(relx=.5, rely=.7, anchor="c")
+        # "Paste"
+        keyboard.write(clipboard)
+        ready.set(1)
 
-ready = tkinter.IntVar()
-info = tkinter.Label(text="Click 'Ready' and select the window to paste to...", wraplength=150, justify="left")
-info.place(relx=.1, rely=.1)
-button = tkinter.Button(root, text="Ready", command=submitFunction)
-button.place(relx=.5, rely=.7, anchor="c")
+    clipboard = root.clipboard_get()
 
-root.wait_variable(ready)
+    clock = tkinter.Label()
+    clock.place(relx=.5, rely=.7, anchor="c")
+
+    ready = tkinter.IntVar()
+    info = tkinter.Label(
+        text="Click 'Ready' and select the window to paste to...",
+        wraplength=150,
+        justify="left",
+    )
+    info.place(relx=.1, rely=.1)
+    button = tkinter.Button(root, text="Ready", command=submitFunction)
+    button.place(relx=.5, rely=.7, anchor="c")
+
+    root.wait_variable(ready)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Re-type clipboard text")
+    parser.add_argument(
+        "-t",
+        "--timer",
+        type=int,
+        default=3,
+        help="Countdown in seconds before typing begins",
+    )
+    args = parser.parse_args()
+    main(args.timer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyautogui
-keyboard
-pywin32
+pyautogui==0.9.54
+keyboard==0.13.5
+pywin32==310

--- a/ss_window.py
+++ b/ss_window.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+
 import tkinter as tk
+
 
 class Overlay(tk.Toplevel):
     def __init__(self, master=None):
@@ -24,7 +26,7 @@ class Overlay(tk.Toplevel):
         self.drag_handle.bind("<ButtonPress-1>", self.start_drag)
         self.drag_handle.bind("<B1-Motion>", self.do_drag)
         self.drag_handle.bind("<ButtonRelease-1>", self.stop_drag)
-        
+
         self.resizing = False
         self.start_x = None
         self.start_y = None

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def test_flake8():
+    subprocess.run(['flake8', '.'], check=True)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,15 @@
+import subprocess
+import pytest
+
+
+scripts = [
+    'pasta.py',
+    'mouse_jiggle.py',
+    'ss_window.py',
+    'ss_window.pyw'
+]
+
+
+@pytest.mark.parametrize('script', scripts)
+def test_compile(script):
+    subprocess.run(['python', '-m', 'py_compile', script], check=True)


### PR DESCRIPTION
## Summary
- add policy reminders to README and docs
- document cross platform notes and CLI usage examples
- pin dependency versions
- add CLI arguments for pasta and mouse jiggle
- add basic flake8 and compile tests

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7aba81b08326a000e0a1eb5c5ce7